### PR TITLE
SMARTER-3290

### DIFF
--- a/src/test/java/mx/com/sw/services/pendings/PendingsTest.java
+++ b/src/test/java/mx/com/sw/services/pendings/PendingsTest.java
@@ -45,6 +45,7 @@ public class PendingsTest {
     /**
     * Método de UT sin peticiones.
     */
+    @Disabled("It is likely that the RFC has pending requests at the time of running the test")
     @Test
     public void testPendings_Token_success_EmptyUUIDs() {
         try {


### PR DESCRIPTION
Se desactiva UT testPendings_Token_success_EmptyUUIDs ya que es probable que el RFC tenga peticiones pendientes al momento de ejecutar la prueba